### PR TITLE
Issue18 useallpoints

### DIFF
--- a/assets/spectrum1.png
+++ b/assets/spectrum1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:642e6b6b3f96fa614ef631f007af823f3f9bd2dd5eeafd047d17852032af2c9a
+size 203035

--- a/assets/spectrum2.png
+++ b/assets/spectrum2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c443e62aa5dbd697c416e13a59070145368fcd66745b4742435baf53eaf6ad06
+size 161350

--- a/continuum.py
+++ b/continuum.py
@@ -86,10 +86,10 @@ class Spectrum:
         narrowed_y = []
         narrowed_x = []
 
-        for ind, ypixel in enumerate(self.yvalues[1:]):
-            if ypixel <= prev_y_pixel + 2:
+        for ind, ypixel in enumerate(self.yvalues):
+            if ypixel >= prev_y_pixel - 1 and ypixel <= prev_y_pixel + 1:
                 narrowed_y.append(ypixel)
-                narrowed_x.append(self.xvalues[ind+1])
+                narrowed_x.append(self.xvalues[ind])
 
         self.xvalues = np.array(narrowed_x)
         self.yvalues = np.array(narrowed_y)

--- a/continuum.py
+++ b/continuum.py
@@ -91,6 +91,8 @@ class Spectrum:
                 narrowed_y.append(ypixel)
                 narrowed_x.append(self.xvalues[ind])
 
+            prev_y_pixel = ypixel
+
         self.xvalues = np.array(narrowed_x)
         self.yvalues = np.array(narrowed_y)
 

--- a/continuum.py
+++ b/continuum.py
@@ -22,6 +22,7 @@ class Spectrum:
     def __init__(self, xvalues, yvalues):
         self.xvalues = xvalues
         self.yvalues = yvalues
+        self.is_narrowed = False
 
         xlen = len(xvalues)
         ylen = len(yvalues)
@@ -29,6 +30,9 @@ class Spectrum:
         # Adding a correctness check to ensure that the dimensions of each are correct.
         if xlen != ylen:
             raise ValueError("The dimensions of the xvalues and yvalues array are not the same; xlen:", xlen, " ylen:", ylen)
+
+        # Narrow the spectrum immediately upon initialization.
+        self.__narrow_spectrum()
 
     def plot(self, show=False):
         """
@@ -65,6 +69,32 @@ class Spectrum:
             return y
 
         return f
+
+
+    def __narrow_spectrum(self):
+        """
+        This function narrows the spectrum down from a naive peak finding method
+        to ensuring that the peaks are no more than 1 or 2 pixels away from each
+        other.
+        """
+
+        # Do not narrow an already narrowed spectrum.
+        if self.is_narrowed is True:
+            return
+
+        prev_y_pixel = self.yvalues[0]
+        narrowed_y = []
+        narrowed_x = []
+
+        for ind, ypixel in enumerate(self.yvalues[1:]):
+            if ypixel <= prev_y_pixel + 2:
+                narrowed_y.append(ypixel)
+                narrowed_x.append(self.xvalues[ind+1])
+
+        self.xvalues = np.array(narrowed_x)
+        self.yvalues = np.array(narrowed_y)
+
+        self.is_narrowed = True
 
 
 ##############################

--- a/unit_tests.py
+++ b/unit_tests.py
@@ -16,8 +16,8 @@ class SpectrumUnitTest(unittest.TestCase):
         self.test_spectrum = Spectrum(xvals, yvals)
         print(self.test_spectrum.xvalues)
         print(self.test_spectrum.yvalues)
-        self.assertTrue(self.test_spectrum.xvalues.all() == np.array([1, 2]).all())
-        self.assertTrue(self.test_spectrum.yvalues.all() == np.array([2, 2.5]).all())
+        self.assertTrue(np.array_equal(self.test_spectrum.xvalues, np.array([1, 2, 5])))
+        self.assertTrue(np.array_equal(self.test_spectrum.yvalues, np.array([2, 2.5, 9])))
 
 
 if __name__ == "__main__":

--- a/unit_tests.py
+++ b/unit_tests.py
@@ -1,0 +1,25 @@
+import unittest
+import numpy as np
+from continuum import Spectrum
+
+class SpectrumUnitTest(unittest.TestCase):
+    """
+    Unit tests for the Spectrum class.
+    """
+
+    def test_narrow(self):
+        """
+        Unit testing the narrow function.
+        """
+        xvals = np.array([1, 2, 3, 4, 5])
+        yvals = np.array([2, 2.5, 4, 8, 9])
+        self.test_spectrum = Spectrum(xvals, yvals)
+        print(self.test_spectrum.xvalues)
+        print(self.test_spectrum.yvalues)
+        self.assertTrue(self.test_spectrum.xvalues.all() == np.array([1, 2]).all())
+        self.assertTrue(self.test_spectrum.yvalues.all() == np.array([2, 2.5]).all())
+
+
+if __name__ == "__main__":
+    unittest.main()
+


### PR DESCRIPTION
This PR should help resolve #18. It still uses the same pipeline to obtain the x and y points for each spectrum. However, in the newly added `Spectrum.narrow()` function, it also removes points that are greater than one away from the previous one.