### PR TITLE
Removes overlapping spectra

### DIFF
--- a/spectrum.py
+++ b/spectrum.py
@@ -35,6 +35,9 @@ class Spectrum:
 
         # Narrow the spectrum immediately upon initialization.
         self.__narrow_spectrum()
+        
+        # Removes overlapping portions of the spectrum
+        self.__remove_overlapping_spectrum() 
 
     def plot(self, show=False):
         """
@@ -100,3 +103,10 @@ class Spectrum:
 
         self.is_narrowed = True
 
+    def __remove_overlapping_spectrum(self):
+        diff_array = np.ediff1d(self.xvalues)
+        max_diff = np.amax(diff_array)
+        max_diff_ind = np.argmax(diff_array)
+
+        while max_diff > diff_threshold:
+            cut(self.xvalues, self.yvalues)

--- a/spectrum.py
+++ b/spectrum.py
@@ -1,19 +1,5 @@
-from astropy.io import fits
-import matplotlib
 import numpy as np
-import scipy.signal
-import os
-import argparse
 import matplotlib.pyplot as plt
-from matplotlib.colors import LogNorm
-import cv2
-import time
-from fitsfile import FitsFile
-from numpy.polynomial.legendre import legfit
-from numpy.polynomial.legendre import Legendre
-from matplotlib.widgets import Button
-import cleanup
-import argparse
 
 
 
@@ -104,9 +90,13 @@ class Spectrum:
         self.is_narrowed = True
 
     def __remove_overlapping_spectrum(self):
-        diff_array = np.ediff1d(self.xvalues)
-        max_diff = np.amax(diff_array)
-        max_diff_ind = np.argmax(diff_array)
+        # Finds the differences between 2 adjacent elements in the array.
+        diff_array = np.ediff1d(self.xvalues) 
 
-        while max_diff > diff_threshold:
-            cut(self.xvalues, self.yvalues)
+        # Diff threshold to detect overlapping spectra
+        diff_threshold = 20
+        diff_dict = dict()
+
+        print(diff_dict)
+
+        pass

--- a/spectrum.py
+++ b/spectrum.py
@@ -2,7 +2,6 @@ import numpy as np
 import matplotlib.pyplot as plt
 
 
-
 class Spectrum:
     """
     This is a class that represents each white spot on the image.
@@ -90,13 +89,26 @@ class Spectrum:
         self.is_narrowed = True
 
     def __remove_overlapping_spectrum(self):
+
         # Finds the differences between 2 adjacent elements in the array.
         diff_array = np.ediff1d(self.xvalues) 
 
         # Diff threshold to detect overlapping spectra
         diff_threshold = 20
-        diff_dict = dict()
 
-        print(diff_dict)
+        # Contains list of indices where next index differs by more than 
+        # diff_threshold
+        diff_ind_list = [] 
 
-        pass
+        for ind, diff in enumerate(diff_array):
+            if diff >= diff_threshold:
+                diff_ind_list.append(ind)
+
+        # Starting and ending indices of the self.xvalues that we ought consider
+        startx = diff_ind_list[0] + 1
+        endx = diff_ind_list[1]
+
+        self.xvalues = self.xvalues[startx:endx]
+        self.yvalues = self.yvalues[startx:endx]
+
+


### PR DESCRIPTION
This PR should resolve #25. It removes overlapping from the continuum fit. However, it is not clear if we are using the total portion of the spectrum. As prescribed by #32, we should write a routine to toggle the spectra.